### PR TITLE
Reduce gunicorn threads from 8 to 1 & make uv not sync at start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ WORKDIR /code
 ENV UV_NO_DEV=1
 ENV UV_LOCKED=1
 RUN uv sync
+ENV UV_NO_SYNC=1
 CMD ["uv", "run", "python", "serve_debug.py"]

--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -4,4 +4,5 @@ WORKDIR /code
 ENV UV_NO_DEV=1
 ENV UV_LOCKED=1
 RUN uv sync
+ENV UV_NO_SYNC=1
 CMD uv run gunicorn --bind :$PORT --workers 1 --threads 1 cohorts:app

--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -4,4 +4,4 @@ WORKDIR /code
 ENV UV_NO_DEV=1
 ENV UV_LOCKED=1
 RUN uv sync
-CMD uv run gunicorn --bind :$PORT --workers 1 --threads 8 cohorts:app
+CMD uv run gunicorn --bind :$PORT --workers 1 --threads 1 cohorts:app


### PR DESCRIPTION
This is the default as per gunicorn docs (https://gunicorn.org/reference/settings/).

Hoping this improves the CPU and boot time situation. We do only assign %15 of a CPU per replica so 8 threads is super overkill.

---

Maybe uv sync is also a big hit, so I also made it not do that. UV_LOCKED=1 and the uv sync on RUN should ensure that we never fail to sync before uv run.